### PR TITLE
Skip apps with no name

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -41,6 +41,9 @@ class DesktopLauncherSkill(MycroftSkill):
 
         for app in gio.app_info_get_all():
             name = app.get_name().lower()
+            if name == None:
+                # Likely an empty .desktop entry, skip it
+                continue
             entry = [app]
             tokenized_name = tokenizer.tokenize(name)[0]
 


### PR DESCRIPTION
If `app.get_name()` returns `None`, the Skill can't handle the app so should just skip it.
Most likely caused by an empty or malformed desktop entry.