### PR TITLE
add system dep to ensure pygobject succeeds

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,4 +3,6 @@ dependencies:
   python:
     - pygobject
   system:
-    apt-get: libcairo-dev
+    apt-get:
+      - libcairo-dev
+      - libgirepository1.0-dev


### PR DESCRIPTION
The pygobject wheel was failing to build and recommending the addition of the `libgirepository1.0-dev` package.

Fixes #15 